### PR TITLE
Fix proxy crash on client disconnect

### DIFF
--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -62,13 +62,13 @@ where
     let mut buffer = [0u8; BUFFER_SIZE];
     let mut buffer_index = 0;
     loop {
-        match parse_stream(&mut buffer, &mut buffer_index, &mut reader, &parser)
+        break match parse_stream(&mut buffer, &mut buffer_index, &mut reader, &parser)
             .and_then(|parsed| Ok(hook(parsed)))
             .and_then(|parsed| serializer.serialize(&parsed))
         {
             Ok(()) => continue,
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
-            Err(e) => return Err(e),
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(()),
+            Err(e) => Err(e),
         }
     }
 }

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -62,9 +62,14 @@ where
     let mut buffer = [0u8; BUFFER_SIZE];
     let mut buffer_index = 0;
     loop {
-        parse_stream(&mut buffer, &mut buffer_index, &mut reader, &parser)
+        match parse_stream(&mut buffer, &mut buffer_index, &mut reader, &parser)
             .and_then(|parsed| Ok(hook(parsed)))
-            .and_then(|parsed| serializer.serialize(&parsed))?;
+            .and_then(|parsed| serializer.serialize(&parsed))
+        {
+            Ok(()) => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(e) => return Err(e),
+        }
     }
 }
 


### PR DESCRIPTION
Proxy crashes after a client disconnects due to `UnexpectedEof` IO error kind.
This pull request fixes this issue by handling this type of error by returning gracefully.