### PR TITLE
Explicitly specify resolver version 2 in workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
   "ftp",
   "proxy"


### PR DESCRIPTION
Fixes warning during GitHub build.